### PR TITLE
Add pluggable market data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,48 @@
 # FII Orchestrator
 
-Setup rápido:
+FII Orchestrator coleta e normaliza dados de mercado de Fundos Imobiliários (FIIs).
+Ele oferece um ETL simples que baixa cotações e proventos de provedores de
+mercado e grava em arquivos Parquet particionados.
 
+## Principais recursos
+- **Provedores plugáveis** via interface `MarketDataProvider`.
+- **Adapters inclusos**:
+  - `YFinanceProvider` para usos de desenvolvimento.
+  - `B3VendorProvider` para integração com CSVs oficiais da B3 com
+    mapeamento de colunas configurável.
+- **ETL de preços e dividendos** executado por `make etl-prices`.
+- Configuração por variáveis de ambiente em `.env`.
+
+## Instalação
 ```bash
 make setup
 ```
+
+## Execução do ETL
+Crie um arquivo `.env` com as configurações desejadas:
+
+```env
+PROVIDER=yf                 # ou b3_vendor
+PRICES_START=2018-01-01     # data inicial
+
+# Parâmetros do B3VendorProvider (se PROVIDER=b3_vendor)
+B3_VENDOR_DIR=./vendor/b3
+B3_PRICE_GLOB=prices_*.csv
+B3_DIV_GLOB=dividends_*.csv
+B3_PRICE_COLMAP={"date":"DATA","ticker":"TICKER","close":"FECHAMENTO","volume":"VOLUME"}
+B3_DIV_COLMAP={"ex_date":"DATA_EX","payment_date":"DATA_PAG","ticker":"TICKER","value":"VALOR"}
+```
+
+Rodar o ETL:
+```bash
+make etl-prices
+```
+Os arquivos Parquet serão gerados em `data/bronze/prices/` e `data/bronze/dividends/`.
+
+## Estrutura do projeto
+- `src/fii_orchestrator/etl/providers/` – implementações de provedores de dados.
+- `src/fii_orchestrator/etl/b3_prices.py` – ponto de entrada do ETL de preços.
+- `Makefile` – tarefas comuns (`setup`, `etl-prices`).
+
+## Licença
+Distribuído sob a licença MIT.

--- a/src/fii_orchestrator/etl/b3_prices.py
+++ b/src/fii_orchestrator/etl/b3_prices.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
-import time
-from datetime import datetime, timedelta
+import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import polars as pl
 from loguru import logger
-import yfinance as yf
-from datetime import timezone
 
 from fii_orchestrator.config import BRONZE
-from fii_orchestrator.etl.schemas import PriceRecord, DividendRecord
 
 REF_FUNDS = BRONZE / "reference" / "funds.parquet"
 PRICES_DIR = BRONZE / "prices"
@@ -16,68 +13,48 @@ DIVS_DIR = BRONZE / "dividends"
 for d in (PRICES_DIR, DIVS_DIR):
     d.mkdir(parents=True, exist_ok=True)
 
+PROVIDER = os.getenv("PROVIDER", "yf").lower()
+
+
 def _load_tickers() -> list[str]:
     if not REF_FUNDS.exists():
-        raise FileNotFoundError(f"Referencia não encontrada: {REF_FUNDS}. Rode reference_funds.py antes.")
+        raise FileNotFoundError(
+            f"Referencia não encontrada: {REF_FUNDS}. Rode reference_funds.py antes."
+        )
     df = pl.read_parquet(REF_FUNDS)
     return df["ticker"].to_list()
 
-def _yf_ticker(t: str) -> str:
-    return f"{t}.SA"  # ajuste simples para B3 no yfinance
 
-def _partitioned_write(df: pl.DataFrame, base: Path, ticker: str, date_col: str, fname_prefix: str):
+def _partitioned_write(
+    df: pl.DataFrame, base: Path, ticker: str, date_col: str, fname_prefix: str
+):
     if df.is_empty():
         return
     # particiona por year/month
     df = df.with_columns(
         pl.col(date_col).dt.year().cast(pl.Utf8).alias("year"),
-        pl.col(date_col).dt.month().cast(pl.Utf8).str.zfill(2).alias("month")
+        pl.col(date_col).dt.month().cast(pl.Utf8).str.zfill(2).alias("month"),
     )
     for (year, month), sub in df.group_by(["year", "month"], maintain_order=True):
         outdir = base / f"ticker={ticker}" / f"year={year}" / f"month={month}"
         outdir.mkdir(parents=True, exist_ok=True)
-        sub.drop(["year", "month"]).write_parquet(outdir / f"{fname_prefix}_{year}{month}.parquet")
+        sub.drop(["year", "month"]).write_parquet(
+            outdir / f"{fname_prefix}_{year}{month}.parquet"
+        )
 
-def fetch_prices_and_dividends(ticker: str, start: str = "2018-01-01", end: str | None = None):
-    yf_t = _yf_ticker(ticker)
-    end = end or (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%d")
-    logger.info(f"{ticker} -> {yf_t} | {start}..{end}")
 
-    tk = yf.Ticker(yf_t)
-    hist = tk.history(start=start, end=end, auto_adjust=False)  # DataFrame pandas
+def _get_provider():
+    if PROVIDER == "b3_vendor":
+        from fii_orchestrator.etl.providers.b3_vendor import B3VendorProvider
 
-    prices: list[PriceRecord] = []
-    if not hist.empty:
-        # prefer close e volume
-        for idx, row in hist.iterrows():
-            if "Close" in row and not pl.Series([row["Close"]]).is_null().any():
-                prices.append(
-                    PriceRecord(
-                        date=datetime(idx.year, idx.month, idx.day),
-                        ticker=ticker,
-                        close=float(row["Close"]),
-                        volume=float(row["Volume"]) if "Volume" in row and row["Volume"] == row["Volume"] else None,
-                        fonte="yfinance",
-                    )
-                )
+        return B3VendorProvider()
+    elif PROVIDER == "yf":
+        from fii_orchestrator.etl.providers.yf_provider import YFinanceProvider
 
-    # dividends: yfinance traz série por data (valor por cota)
-    divs_pd = tk.dividends
-    dividends: list[DividendRecord] = []
-    if divs_pd is not None and not divs_pd.empty:
-        for idx, val in divs_pd.items():
-            dividends.append(
-                DividendRecord(
-                    ex_date=datetime(idx.year, idx.month, idx.day),
-                    payment_date=None,
-                    ticker=ticker,
-                    value=float(val),
-                    tipo="dividend",
-                    fonte="yfinance",
-                )
-            )
+        return YFinanceProvider()
+    else:
+        raise ValueError(f"PROVIDER desconhecido: {PROVIDER}")
 
-    return prices, dividends
 
 def run():
     tickers = _load_tickers()
@@ -85,21 +62,35 @@ def run():
         logger.warning("Nenhum ticker na referência.")
         return
 
-    for i, t in enumerate(tickers, 1):
+    provider = _get_provider()
+    start = datetime.fromisoformat(os.getenv("PRICES_START", "2018-01-01")).replace(
+        tzinfo=timezone.utc
+    )
+    end_env = os.getenv("PRICES_END")
+    end = (
+        datetime.fromisoformat(end_env).replace(tzinfo=timezone.utc)
+        if end_env
+        else (datetime.now(timezone.utc) + timedelta(days=1))
+    )
+
+    for t in tickers:
         try:
-            prices, dividends = fetch_prices_and_dividends(t)
-            # salvar preços
+            prices = list(provider.fetch_prices(t, start, end))
             if prices:
-                dfp = pl.DataFrame([p.model_dump() for p in prices])
+                dfp = pl.DataFrame([r.model_dump() for r in prices])
                 _partitioned_write(dfp, PRICES_DIR, t, "date", "prices")
-            # salvar proventos
-            if dividends:
-                dfd = pl.DataFrame([d.model_dump() for d in dividends])
+
+            divs = list(provider.fetch_dividends(t, start, end))
+            if divs:
+                dfd = pl.DataFrame([r.model_dump() for r in divs])
                 _partitioned_write(dfd, DIVS_DIR, t, "ex_date", "dividends")
-            logger.info(f"{t}: prices={len(prices)} dividends={len(dividends)}")
-            time.sleep(0.8)  # educado com a API
+
+            logger.info(
+                f"{t}: prices={len(prices)} dividends={len(divs)} via {PROVIDER}"
+            )
         except Exception as e:
             logger.exception(f"Falha em {t}: {e}")
+
 
 if __name__ == "__main__":
     run()

--- a/src/fii_orchestrator/etl/providers/b3_vendor.py
+++ b/src/fii_orchestrator/etl/providers/b3_vendor.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+import os
+import json
+from datetime import datetime
+from pathlib import Path
+import polars as pl
+from loguru import logger
+from dotenv import load_dotenv
+from fii_orchestrator.etl.schemas import PriceRecord, DividendRecord
+
+load_dotenv()
+
+# Diretório com arquivos CSV “oficiais” já baixados (SFTP, cron, etc.)
+B3_VENDOR_DIR = Path(os.getenv("B3_VENDOR_DIR", "./vendor/b3")).resolve()
+
+# Mapas de colunas (configuráveis no .env para não re-compilar)
+# Ex.: B3_PRICE_COLMAP='{"date":"DATA","ticker":"TICKER","close":"FECHAMENTO","volume":"VOLUME"}'
+PRICE_COLMAP = json.loads(os.getenv("B3_PRICE_COLMAP", "{}"))
+DIV_COLMAP = json.loads(os.getenv("B3_DIV_COLMAP", "{}"))
+
+
+def _read_price_csv(path: Path) -> pl.DataFrame:
+    df = pl.read_csv(path, ignore_errors=True)
+    # aplica renomeações do COLMAP (se houver)
+    if PRICE_COLMAP:
+        df = df.rename(
+            {k: v for k, v in PRICE_COLMAP.items() if k in df.columns}
+            | {v: k for k, v in PRICE_COLMAP.items() if v in df.columns}
+        )
+    return df
+
+
+def _read_div_csv(path: Path) -> pl.DataFrame:
+    df = pl.read_csv(path, ignore_errors=True)
+    if DIV_COLMAP:
+        df = df.rename(
+            {k: v for k, v in DIV_COLMAP.items() if k in df.columns}
+            | {v: k for k, v in DIV_COLMAP.items() if v in df.columns}
+        )
+    return df
+
+
+class B3VendorProvider:
+    """
+    Lê arquivos CSV "oficiais" já sincronizados localmente (SFTP/REST->dump),
+    normaliza para PriceRecord/DividendRecord.
+    """
+
+    def __init__(self):
+        self.price_glob = os.getenv("B3_PRICE_GLOB", "prices_*.csv")
+        self.div_glob = os.getenv("B3_DIV_GLOB", "dividends_*.csv")
+
+    def _iter_price_files(self):
+        yield from sorted(B3_VENDOR_DIR.glob(self.price_glob))
+
+    def _iter_div_files(self):
+        yield from sorted(B3_VENDOR_DIR.glob(self.div_glob))
+
+    def fetch_prices(self, ticker: str, start: datetime, end: datetime):
+        ticker = ticker.upper()
+        for csv_path in self._iter_price_files():
+            df = _read_price_csv(csv_path)
+            # Esperado: colunas padronizadas pós-map: ['date','ticker','close','volume', ...]
+            missing = [c for c in ["date", "ticker", "close"] if c not in df.columns]
+            if missing:
+                logger.warning(f"{csv_path} sem colunas {missing}, pulando.")
+                continue
+
+            # filtros de ticker e janela
+            out = (
+                df.filter((pl.col("ticker").str.to_uppercase() == ticker))
+                .with_columns(
+                    pl.col("date").str.strptime(pl.Date, strict=False).cast(pl.Datetime)
+                )
+                .filter(
+                    (pl.col("date") >= pl.lit(start)) & (pl.col("date") <= pl.lit(end))
+                )
+                .select(
+                    [
+                        "date",
+                        "ticker",
+                        "close",
+                        pl.col("volume").fill_null(0).alias("volume"),
+                    ]
+                )
+            )
+
+            for r in out.iter_rows(named=True):
+                yield PriceRecord(
+                    date=r["date"].to_pydatetime(),
+                    ticker=r["ticker"],
+                    close=float(r["close"]),
+                    volume=float(r["volume"]) if r["volume"] is not None else None,
+                    fonte="b3_vendor",
+                )
+
+    def fetch_dividends(self, ticker: str, start: datetime, end: datetime):
+        ticker = ticker.upper()
+        for csv_path in self._iter_div_files():
+            df = _read_div_csv(csv_path)
+            # Esperado: ['ex_date','payment_date','ticker','value','tipo'?]
+            # Se vier como 'event_date' e 'amount', mapeie no .env com B3_DIV_COLMAP
+            # Ex.: {"ex_date":"DATA_EX","payment_date":"PAGAMENTO","ticker":"TICKER","value":"VALOR"}
+            if (
+                "ex_date" not in df.columns
+                or "ticker" not in df.columns
+                or "value" not in df.columns
+            ):
+                logger.warning(f"{csv_path} faltam colunas essenciais, pulando.")
+                continue
+
+            out = (
+                df.filter((pl.col("ticker").str.to_uppercase() == ticker))
+                .with_columns(
+                    pl.col("ex_date")
+                    .str.strptime(pl.Date, strict=False)
+                    .cast(pl.Datetime),
+                    pl.when(pl.col("payment_date").is_not_null())
+                    .then(
+                        pl.col("payment_date")
+                        .str.strptime(pl.Date, strict=False)
+                        .cast(pl.Datetime)
+                    )
+                    .otherwise(None)
+                    .alias("payment_date"),
+                )
+                .filter(
+                    (pl.col("ex_date") >= pl.lit(start))
+                    & (pl.col("ex_date") <= pl.lit(end))
+                )
+                .select(["ex_date", "payment_date", "ticker", "value"])
+            )
+
+            for r in out.iter_rows(named=True):
+                yield DividendRecord(
+                    ex_date=r["ex_date"].to_pydatetime(),
+                    payment_date=(
+                        r["payment_date"].to_pydatetime() if r["payment_date"] else None
+                    ),
+                    ticker=r["ticker"],
+                    value=float(r["value"]),
+                    tipo="dividend",
+                    fonte="b3_vendor",
+                )

--- a/src/fii_orchestrator/etl/providers/base.py
+++ b/src/fii_orchestrator/etl/providers/base.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Iterable
+
+from fii_orchestrator.etl.schemas import PriceRecord, DividendRecord
+
+
+class MarketDataProvider(ABC):
+    @abstractmethod
+    def fetch_prices(
+        self, ticker: str, start: datetime, end: datetime
+    ) -> Iterable[PriceRecord]:
+        """Return price records for ticker between start and end."""
+
+    @abstractmethod
+    def fetch_dividends(
+        self, ticker: str, start: datetime, end: datetime
+    ) -> Iterable[DividendRecord]:
+        """Return dividend records for ticker between start and end."""

--- a/src/fii_orchestrator/etl/providers/yf_provider.py
+++ b/src/fii_orchestrator/etl/providers/yf_provider.py
@@ -1,0 +1,63 @@
+import time
+from datetime import datetime
+from typing import Iterable
+
+import yfinance as yf
+from fii_orchestrator.etl.schemas import PriceRecord, DividendRecord
+from .base import MarketDataProvider
+
+
+class YFinanceProvider(MarketDataProvider):
+    def __init__(self, pause: float = 0.8):
+        self.pause = pause
+
+    @staticmethod
+    def _yf_ticker(t: str) -> str:
+        return f"{t}.SA"
+
+    def fetch_prices(
+        self, ticker: str, start: datetime, end: datetime
+    ) -> Iterable[PriceRecord]:
+        yf_t = self._yf_ticker(ticker)
+        tk = yf.Ticker(yf_t)
+        hist = tk.history(
+            start=start.strftime("%Y-%m-%d"),
+            end=end.strftime("%Y-%m-%d"),
+            auto_adjust=False,
+        )
+        for idx, row in hist.iterrows():
+            close = row.get("Close")
+            if close == close:  # not NaN
+                volume = row.get("Volume")
+                yield PriceRecord(
+                    date=datetime(idx.year, idx.month, idx.day),
+                    ticker=ticker,
+                    close=float(close),
+                    volume=float(volume) if volume == volume else None,
+                    fonte="yfinance",
+                )
+        if self.pause:
+            time.sleep(self.pause)
+
+    def fetch_dividends(
+        self, ticker: str, start: datetime, end: datetime
+    ) -> Iterable[DividendRecord]:
+        yf_t = self._yf_ticker(ticker)
+        tk = yf.Ticker(yf_t)
+        divs_pd = tk.dividends
+        if divs_pd is not None and not divs_pd.empty:
+            for idx, val in divs_pd.items():
+                d_dt = datetime(idx.year, idx.month, idx.day)
+                if d_dt >= start.replace(tzinfo=None) and d_dt <= end.replace(
+                    tzinfo=None
+                ):
+                    yield DividendRecord(
+                        ex_date=d_dt,
+                        payment_date=None,
+                        ticker=ticker,
+                        value=float(val),
+                        tipo="dividend",
+                        fonte="yfinance",
+                    )
+        if self.pause:
+            time.sleep(self.pause)

--- a/src/fii_orchestrator/etl/reference_funds.py
+++ b/src/fii_orchestrator/etl/reference_funds.py
@@ -5,13 +5,13 @@ from loguru import logger
 from dotenv import load_dotenv
 
 from fii_orchestrator.config import BRONZE
-from fii_orchestrator.etl.schemas import FundRef
 
 load_dotenv()
 
 REF_DIR = BRONZE / "reference"
 REF_DIR.mkdir(parents=True, exist_ok=True)
 FUNDS_PARQUET = REF_DIR / "funds.parquet"
+
 
 def _from_env_tickers() -> pl.DataFrame:
     raw = os.getenv("FII_TICKERS", "").strip()
@@ -20,11 +20,14 @@ def _from_env_tickers() -> pl.DataFrame:
     tickers = [t.strip().upper() for t in raw.split(",") if t.strip()]
     return pl.DataFrame({"ticker": tickers, "fonte": ["env"] * len(tickers)})
 
+
 def _from_seed_csv() -> pl.DataFrame:
     csv_path = os.getenv("FII_REFERENCE_CSV", "").strip()
     if not csv_path or not Path(csv_path).exists():
         return pl.DataFrame({"ticker": []})
-    df = pl.read_csv(csv_path, dtypes={"ticker": pl.Utf8, "cnpj": pl.Utf8, "razao_social": pl.Utf8})
+    df = pl.read_csv(
+        csv_path, dtypes={"ticker": pl.Utf8, "cnpj": pl.Utf8, "razao_social": pl.Utf8}
+    )
     df = df.with_columns(
         pl.col("ticker").str.to_uppercase(),
         pl.lit("seed_csv").alias("fonte"),
@@ -34,6 +37,7 @@ def _from_seed_csv() -> pl.DataFrame:
         if col not in df.columns:
             df = df.with_columns(pl.lit(None).alias(col))
     return df.select(["ticker", "cnpj", "razao_social", "fonte"])
+
 
 def run():
     logger.info("Construindo referência FII <-> CNPJ")
@@ -50,7 +54,9 @@ def run():
     df = (
         df.with_columns(
             pl.when(pl.col("cnpj").is_not_null() | pl.col("razao_social").is_not_null())
-            .then(1).otherwise(0).alias("score")
+            .then(1)
+            .otherwise(0)
+            .alias("score")
         )
         .sort(["ticker", "score"], descending=[False, True])
         .unique(subset=["ticker"], keep="first")
@@ -59,6 +65,7 @@ def run():
 
     df.write_parquet(FUNDS_PARQUET)
     logger.info(f"Referencia salva em {FUNDS_PARQUET} ({df.height} FIIs)")
+
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
## Summary
- add MarketDataProvider interface with YFinance and B3 vendor implementations
- inject provider into price ETL based on `PROVIDER` env var
- add project README with setup and ETL usage instructions

## Testing
- `poetry run ruff check .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e91aabc4883238171a2474d4c682b